### PR TITLE
Prevent simultaneous press of multiple buttons

### DIFF
--- a/Re-Resolver/Base.lproj/LaunchScreen.storyboard
+++ b/Re-Resolver/Base.lproj/LaunchScreen.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>

--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -93,6 +93,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Menu" id="1nq-mJ-tD6"/>
+                    <connections>
+                        <outlet property="askButton" destination="6IB-l3-GxU" id="0jW-TA-ua5"/>
+                        <outlet property="chooseButton" destination="MrX-Fm-NZa" id="WSv-6I-Wrv"/>
+                        <outlet property="decideButton" destination="qHR-2a-E8z" id="nQU-Wh-XCV"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Re-Resolver/ChoiceResultsViewController.swift
+++ b/Re-Resolver/ChoiceResultsViewController.swift
@@ -37,6 +37,8 @@ class ChoiceResultsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
   
+        choiceButton.exclusiveTouch = true
+        
         if let title = menuTitle  {
             navigationItem.title = title
         }

--- a/Re-Resolver/ChooseViewController.swift
+++ b/Re-Resolver/ChooseViewController.swift
@@ -32,8 +32,18 @@ NewChoiceDelegate {
         // Uncomment the following line to preserve selection between presentations
         // self.clearsSelectionOnViewWillAppear = false
 
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem()
+        
+        // prevent multiple items in navigation bar
+        // from being pressed simultaneously, which
+        // can corrupt the navigation stack
+           navigationController?.navigationBar.exclusiveTouch = true
+        if let navigationBarViews = navigationController?.navigationBar.subviews  {
+            for view in navigationBarViews  {
+                view.exclusiveTouch = true
+            }
+        }
+        
+        chooseButton.exclusiveTouch = true
         
         // set the data file name for load/save recents functionality
         recentList.dataFileName = ResolverConstants.recentChoicesFileName

--- a/Re-Resolver/InstructionsViewController.swift
+++ b/Re-Resolver/InstructionsViewController.swift
@@ -19,6 +19,7 @@ class InstructionsViewController: UIViewController {
     // Make sure the beginning of the text
     // is visible in the scroll pane
     override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         textView.setContentOffset(CGPoint.zero, animated: false)
     }
    

--- a/Re-Resolver/NewChoiceViewController.swift
+++ b/Re-Resolver/NewChoiceViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 
 // This is the controller for the New Choice screen,
-// which allows the user to enter a new choice from the keybaord
+// which allows the user to enter a new choice from the keyboard
 
 
 protocol NewChoiceDelegate: class  {
@@ -26,6 +26,16 @@ RecentItemDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         textField.delegate = self
+        
+        // prevent multiple items in navigation bar
+        // from being pressed simultaneously, which
+        // can corrupt the navigation stack
+     
+        if let navigationBarViews = navigationController?.navigationBar.subviews  {
+            for view in navigationBarViews  {
+                view.exclusiveTouch = true
+            }
+        }
     }
     
     override func viewWillAppear(animated: Bool) {

--- a/Re-Resolver/RecentTableViewController.swift
+++ b/Re-Resolver/RecentTableViewController.swift
@@ -25,11 +25,6 @@ class RecentTableViewController: UITableViewController {
         choiceList.dataFileName = ResolverConstants.recentChoicesFileName
         choiceList.load()
         
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem()
     }
 
     override func didReceiveMemoryWarning() {

--- a/Re-Resolver/ResolverMenuViewController.swift
+++ b/Re-Resolver/ResolverMenuViewController.swift
@@ -21,6 +21,22 @@ import UIKit
 class ResolverMenuViewController: UIViewController {
 
     
+    @IBOutlet weak var decideButton: UIButton!
+    @IBOutlet weak var chooseButton: UIButton!
+    @IBOutlet weak var askButton: UIButton!
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // set buttons so that only one at a time
+        // will respond to touches
+        
+        decideButton.exclusiveTouch = true
+        chooseButton.exclusiveTouch = true
+        askButton.exclusiveTouch = true
+    }
+    
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         


### PR DESCRIPTION
This commit fixes strange navigation issues and problems with
the navigation bar titles that occurred when multiple buttons were
pressed simultaneously.

Now, only one button at a time on the main menu can receive a press event.
Similar changes were made to buttons in the navigation bars.

Prior to these fixes, pressing multiple buttons led to
two navigation actions being executed simultaneously, confusing navigation.
When the buttons were in the navigation bar, the titles of each screen would also be
overlaid on each other and error log messages were triggered:

2016-05-23 06:37:18.348 Re-Resolver[3854:1558530] nested push animation can result in corrupted navigation bar
2016-05-23 06:37:18.725 Re-Resolver[3854:1558530] Finishing up a navigation transition in an unexpected state. Navigation Bar subview tree might get corrupted.

Testing of prior versions of this app also occasionally triggered a condition where
pressing a back button on the navigation bar did not move back. It's not known - but hoped -
that the issue is also corrected with these fixes.