### PR TITLE
Fix VoiceOver support

### DIFF
--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -201,6 +201,7 @@
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" showsTouchWhenHighlighted="YES" lineBreakMode="wordWrap" translatesAutoresizingMaskIntoConstraints="NO" id="upK-TA-daT">
                                 <rect key="frame" x="150" y="240" width="300" height="200"/>
+                                <accessibility key="accessibilityConfiguration" hint="Displays a new decision when pressed." label="Results"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="200" id="KJt-1f-g0w"/>
                                     <constraint firstAttribute="width" constant="300" id="WZV-eR-GTg"/>
@@ -280,6 +281,7 @@
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Oaw-Oo-BK3">
                                 <rect key="frame" x="20" y="164" width="560" height="30"/>
                                 <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                                <accessibility key="accessibilityConfiguration" hint="Allows entry of a new choice." label="Choice"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>

--- a/Re-Resolver/ChoiceResultsViewController.swift
+++ b/Re-Resolver/ChoiceResultsViewController.swift
@@ -31,7 +31,9 @@ class ChoiceResultsViewController: UIViewController {
     
     @IBAction func choiceButtonPressed(button: UIButton) {
         
-        button.setTitle(choiceList.choose(), forState: .Normal)
+        let choice = choiceList.choose()
+        button.setTitle(choice, forState: .Normal)
+        choiceButton.accessibilityLabel = choice
     }
     
     override func viewDidLoad() {
@@ -47,7 +49,9 @@ class ChoiceResultsViewController: UIViewController {
     
             // Check that there are choices before displaying one!
             if choiceList.choices.count > 0  {
-                choiceButton.setTitle(choiceList.choose(), forState: .Normal)
+                let choice =  choiceList.choose()
+                choiceButton.setTitle(choice, forState: .Normal)
+                choiceButton.accessibilityLabel = choice
             }
             
             choiceButton.enabled = false
@@ -70,9 +74,14 @@ class ChoiceResultsViewController: UIViewController {
                 choiceButton.titleLabel?.textColor = UIColor.redColor()
                 
                 // Added an animation to give feedback that the shake was recognized.
-                UIView.transitionWithView(choiceButton.titleLabel!, duration: 1.0, options: .TransitionFlipFromLeft,
+                UIView.transitionWithView(choiceButton.titleLabel!, duration: 0.5, options: .TransitionFlipFromLeft,
                                           animations: {
-                                            self.choiceButton.setTitle(self.choiceList.choose(), forState: .Normal)
+                                            let choice = self.choiceList.choose()
+                                            self.choiceButton.setTitle(choice, forState: .Normal)
+                                            self.choiceButton.accessibilityLabel = choice
+                                            
+                                            // If VoiceOver is enabled, speak the new result
+                                            UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, choice)
                     }, completion: nil )
             }
         }


### PR DESCRIPTION
The changes on this branch resolve issues #9  and #10, accessibility with VoiceOver enabled, to better support visually impaired and other users.

On the "Decide" and "Ask" screen, there is a big blank button where the results go. The button was described by VoiceOver by its image title, which was something like "reresolver-button-300px".

Now, VoiceOver announces this as "Results. Button", and will also give a delayed hint "Displays a new 
decision when pressed".

There's also a feature on these screens - not yet in user documentation, but part of the original Resolver app - that when the phone is shaken, a new result will appear. VoiceOver will announce this new result automatically when it appears after the phone is shaken.

VoiceOver improvements have also been added to the "New Choice" screen. The blank TextField was previously described by VoiceOver as "Textfield". It is now described as "Choice. Textfield" with the delayed hint "Allows entry of a new choice".



