### PR TITLE
Change "Recent" screen to return directly to "Choose" list

### DIFF
--- a/Re-Resolver/ChooseViewController.swift
+++ b/Re-Resolver/ChooseViewController.swift
@@ -14,12 +14,17 @@ import UIKit
 // This controller acts as a delegate for the NewChoiceViewController,
 // and updates the table when a new choice is entered on that screen.
 //
+// The controller also acts as a delegate for the "Recent" controller
+// and similarly updates the table with the choice selected from the
+// Recent table.
+//
 // When the "Choose" button is pressed, another screen is displayed
 // that shows a random selection from the table of choices.
 class ChooseViewController: UIViewController,
 UITableViewDataSource,
 UITableViewDelegate,
-NewChoiceDelegate {
+NewChoiceDelegate,
+RecentItemDelegate {
     
     
     var choiceList =  ChoiceList(choices: [String]()) // current choices
@@ -32,9 +37,6 @@ NewChoiceDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
-
         
         // prevent multiple items in navigation bar
         // from being pressed simultaneously, which
@@ -132,11 +134,9 @@ NewChoiceDelegate {
         
     }
     
-
-    
-    // MARK: - NewChoiceDelegate
-    // Used when choice added on the "New choice" screen
-    func choiceAdded(choice: String) {
+    // Add a new choice to the data model, the table,
+    // and the recent list
+    func addChoiceToList(choice: String)  {
         
         let numberOfChoicesBeforeAddition = choiceList.choices.count
         choiceList.choices.append(choice)
@@ -150,11 +150,28 @@ NewChoiceDelegate {
             recentList.choices.append(choice)
             recentList.save()
         }
-      
+        
         // make sure the choose button is enabled, as we now have at least 1 item
         chooseButton.enabled = true
         chooseButton.alpha = 1
+    }
+
+    
+    // MARK: - NewChoiceDelegate
+    // Used when choice added on the "New choice" screen
+    func choiceAdded(choice: String) {
+        
+        navigationController?.popViewControllerAnimated(true)
+        addChoiceToList(choice)
         
     }
+    
+    // MARK: RecentItemDelegate
+    // Used when a choice is added from the "Recent" screen
+    func recentItemSelected(item: String)  {
+        navigationController?.popToViewController(self, animated: true)
+        addChoiceToList(item)
+    }
+    
     
 }

--- a/Re-Resolver/NewChoiceViewController.swift
+++ b/Re-Resolver/NewChoiceViewController.swift
@@ -17,8 +17,7 @@ protocol NewChoiceDelegate: class  {
     func choiceAdded(choice: String)
 }
 
-class NewChoiceViewController: UIViewController, UITextFieldDelegate,
-RecentItemDelegate {
+class NewChoiceViewController: UIViewController, UITextFieldDelegate {
 
     @IBOutlet private weak var textField: UITextField!
     weak var delegate: NewChoiceDelegate?
@@ -51,22 +50,22 @@ RecentItemDelegate {
         
         textField.resignFirstResponder()
         delegate?.choiceAdded(textField.text!)
-        navigationController?.popViewControllerAnimated(true)
         return true
     }
    
-    // MARK: RecentItemDelegate
-    // Set the text in the field to whatever
-    // recent item was selected from the table
-    func recentItemSelected(item: String)  {
-        textField.text = item
-    }
-    
+      
     
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
         if segue.identifier == "RecentSegue"  {
             let recentController = segue.destinationViewController as! RecentTableViewController
-            recentController.delegate = self
+            // our NewChoiceDelegate will also be the RecentItem delegate
+            // for the RecentTableViewController
+            //
+            // The ChooseViewController currently handles both
+            // of these responsibilities
+            if let delegate = delegate  {
+                recentController.delegate = delegate as! ChooseViewController
+            }
             textField.resignFirstResponder()
         }
     }

--- a/Re-Resolver/RecentTableViewController.swift
+++ b/Re-Resolver/RecentTableViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+// TODO: Consider replacing with unwind segue
 protocol RecentItemDelegate: class  {
     func recentItemSelected(item: String)
 }
@@ -54,10 +55,9 @@ class RecentTableViewController: UITableViewController {
     
 
     // Handle taps on the rows by notifying the delegate of the text of the row
-    // and then popping back to the previous screen
+    // The delegate will also handle navigation
     override func tableView(tableView: UITableView, didSelectRowAtIndexPath indexPath: NSIndexPath) {
         delegate?.recentItemSelected(choiceList.choices[indexPath.row])
-        navigationController?.popViewControllerAnimated(true)
     }
     
     // Enable slide to delete on the table view.


### PR DESCRIPTION
The "Recent" screen previously returned to the "New Choice"
screen so that the selected recent entry could be edited before
it was added to the list of choices.

Now, when a Recent item is selected, the "New Choice" screen
is bypassed and the item is added directly to the "Choose" screen.
This is the behavior of the classic app.

There may be an opportunity for refactoring after this change. The
"ChooseViewController" is now serving as the NewChoiceDelegate and
the RecentItemDelegate, to handle selections from the "New Choice" screen
and the "Recent Item" screen. The "New Choice" screen handles setting
the previous screen, the ChooseViewController, as the RecentItemDelegate.
This seems strange and perhaps both delegates could be replaced with an
unwind segue back to ChooseViewController.