### PR TITLE
Make back buttons resizable

### DIFF
--- a/Re-Resolver/Assets.xcassets/navbar_button.imageset/Contents.json
+++ b/Re-Resolver/Assets.xcassets/navbar_button.imageset/Contents.json
@@ -1,6 +1,17 @@
 {
   "images" : [
     {
+      "resizing" : {
+        "mode" : "3-part-horizontal",
+        "center" : {
+          "mode" : "tile",
+          "width" : 1
+        },
+        "cap-insets" : {
+          "right" : 12,
+          "left" : 15
+        }
+      },
       "idiom" : "universal",
       "filename" : "navbar_button.png",
       "scale" : "1x"


### PR DESCRIPTION
This uses the Xcode image slicing feature so that the back buttons in the navigation bar are automatically sized to the correct width based on the length of the text that they contain.