### PR TITLE
Fix unwanted display of "<" back indicator on custom navbar images.

### DIFF
--- a/Re-Resolver/AppDelegate.swift
+++ b/Re-Resolver/AppDelegate.swift
@@ -23,6 +23,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let backImage = UIImage(named: "navbar_button")
         barButtonAppearance.setBackButtonBackgroundImage(backImage, for: UIControlState(), barMetrics: .default  )
         
+        // If this app is running on iOS 11 or higher,
+        // fix an apparent iOS bug where the "<" indicator
+        // is shown on custom back buttons in navigation bars
+        // This code may need to be updated if this is determined
+        // to be an iOS bug and it is fixed in later updates.
+        if #available (iOS 11.0, *)  {
+            self.hideNavBarDefaultBackIndicator()
+        }
+        
         // register defaults for background gradient
         let dictionary = ["ColorPreference": 0]
         UserDefaults.standard.register(defaults: dictionary)
@@ -37,6 +46,23 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    // This is used only in iOS 11 and higher to work around
+    // a bug that displays the default "<" back indicator
+    // in navigation bars even when a custom button image is
+    // used.
+    func hideNavBarDefaultBackIndicator()  {
+        // hide default "<" image
+        let navBarAppearance = UINavigationBar.appearance()
+        navBarAppearance.backIndicatorImage = UIImage()
+        navBarAppearance.backIndicatorTransitionMaskImage = UIImage()
+        
+        // adjust text label on the custom back button so that it
+        // isn't smashed up to the left side of the display.
+        let buttonTitleAdjustment = UIOffsetMake(-20,0)
+        let barButtonAppearance = UIBarButtonItem.appearance()
+        barButtonAppearance.setBackButtonTitlePositionAdjustment(buttonTitleAdjustment, for: .default)
+    }
+    
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.


### PR DESCRIPTION
This works around the problem documented in issue #31:
 back buttons in the navigation area have the default "<" prompt even with the custom images.

I have tested on iOS 10 and iOS 11.

This approach is somewhat fragile. If and only if the app is running on iOS 11 or higher, it executes code that works around the issue. The code makes an adjustment to the offset of the title text on the buttons that would be problematic if there were no issue, as in iOS 10.

Therefore, if the problem is caused by an iOS bug and the iOS bug is fixed in a future version of iOS, the workaround code will execute (because the version is higher than iOS 11) and the offset of the title text would be incorrect (and ugly).

This is a relatively quick fix, and if a future version breaks again I think I can get fixes out in a few days. If this turns out to be a poor approach, I still have alternate solutions - likely to be more robust - from Ziqiao which I have not yet tested.