### PR TITLE
Change uiwebview to wkwebview

### DIFF
--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -391,23 +391,22 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <webView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gwm-69-w3E">
-                                <rect key="frame" x="16" y="72" width="343" height="580"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <dataDetectorType key="dataDetectorTypes"/>
-                            </webView>
+                            <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eN4-bF-vBV">
+                                <rect key="frame" x="16" y="72" width="343" height="587"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="gwm-69-w3E" firstAttribute="leading" secondItem="sC1-LV-2Q5" secondAttribute="leadingMargin" id="2r6-Md-jTY"/>
-                            <constraint firstItem="gwm-69-w3E" firstAttribute="top" secondItem="T9P-Ns-EH1" secondAttribute="bottom" constant="8" id="FNO-KA-VeA"/>
-                            <constraint firstItem="e3z-Lp-RxF" firstAttribute="top" secondItem="gwm-69-w3E" secondAttribute="bottom" constant="15" id="W0a-SJ-ciS"/>
-                            <constraint firstItem="gwm-69-w3E" firstAttribute="trailing" secondItem="sC1-LV-2Q5" secondAttribute="trailingMargin" id="ynS-R4-GcR"/>
+                            <constraint firstItem="eN4-bF-vBV" firstAttribute="top" secondItem="T9P-Ns-EH1" secondAttribute="bottom" constant="8" id="NSL-oU-3X3"/>
+                            <constraint firstItem="eN4-bF-vBV" firstAttribute="leading" secondItem="sC1-LV-2Q5" secondAttribute="leadingMargin" id="NrX-Cs-XRA"/>
+                            <constraint firstItem="eN4-bF-vBV" firstAttribute="trailing" secondItem="sC1-LV-2Q5" secondAttribute="trailingMargin" id="bpx-je-87H"/>
+                            <constraint firstItem="e3z-Lp-RxF" firstAttribute="top" secondItem="eN4-bF-vBV" secondAttribute="bottom" constant="8" id="fIT-E8-YOx"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Instructions" id="VOi-TB-aOH"/>
                     <connections>
-                        <outlet property="webView" destination="gwm-69-w3E" id="SIx-UQ-0aI"/>
+                        <outlet property="enclosingView" destination="eN4-bF-vBV" id="z9a-bX-oMX"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cSb-2M-kvq" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Re-Resolver/InstructionsViewController.swift
+++ b/Re-Resolver/InstructionsViewController.swift
@@ -14,14 +14,17 @@ import WebKit
 class InstructionsViewController: UIViewController, WKNavigationDelegate {
 
     // Note: WKWebView may have problems
-    // when instantiated via storyboards prior to iOS 11.
-    // The storyboard for this scene has a generic UIView
+    // when instantiated via storyboards prior to iOS 11,
+    // but at the time of this writing, the app still functions
+    // under iOS 9.3. Therefore the WKWebView is added from this code
+    // instead of the storyboard.
+    //
+    // The storyboard for this scene has a generic UIView (enclosingView)
     // in place to take advantage of the AutoLayout system,
     // while the main component of the scene, the WKWebView,
-    // is sized to match this UIView and added as a subview.
+    // is added as a subview and sized to fit in viewDIdLayoutSubviews.
     @IBOutlet weak var enclosingView: UIView!
-    var webView: WKWebView! // implicit unwrap seems risky here
-    
+    let webView = WKWebView()
     
     // Create and configure the WKWebView and load localized help
     // text.
@@ -29,17 +32,14 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
         super.viewDidLoad()
         
         // This could have been done in the storyboard, but
-        // I wanted the view to be visible on the board.
+        // I wanted the enclosingView to be visible in Interface Builder.
         enclosingView.backgroundColor = UIColor.clear
     
-        let webConfiguration = WKWebViewConfiguration()
-        webConfiguration.preferences.javaScriptEnabled = false
-        webView = WKWebView(frame: enclosingView.frame, configuration: webConfiguration)
-    
+        // Configure the webView
+        webView.configuration.preferences.javaScriptEnabled = false
         webView.backgroundColor = UIColor.clear
         webView.isOpaque = false
-        view.addSubview(webView)
-
+        enclosingView.addSubview(webView)
         webView.navigationDelegate = self
         
         // Get the preferred language. This should be more flexible,
@@ -54,19 +54,24 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
             webView.loadFileURL(url, allowingReadAccessTo: url)
         }
     }
-    
+
+    // Overridden to set the webView to fill
+    // the bounds of the enclosingView after
+    // layout constraints have been applied
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        webView.frame = enclosingView.frame
+        webView.frame =
+            CGRect(x: 0.0, y: 0.0, width: enclosingView.frame.width, height: enclosingView.frame.height)
     }
 
     // Load links in the about page in the Safari app, instead of the
-    // WebView. This avoids the following problems and work:
+    // WKWebView. This avoids the following problems and work:
     //    1. App Transport Security issues with http websites
     //    2. Need to add and program navigation buttons for the webview
+    //    3. Inconsistencies with previous versions of the app
     //
-    //   There was a problem with VoiceOver when connecting to the GitHub
-    //   link in the initial test.
+    //   TODO: Test with VoiceOver. There was a problem with VoiceOver when connecting to the GitHub
+    //   link in the initial test that used UIWebView instead of WKWebView.
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         
         if navigationAction.navigationType == .linkActivated  {
@@ -76,5 +81,4 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
             decisionHandler(.allow)
         }
     }
-    
 }

--- a/Re-Resolver/InstructionsViewController.swift
+++ b/Re-Resolver/InstructionsViewController.swift
@@ -7,45 +7,59 @@
 //
 
 import UIKit
+import WebKit
 
-
-// This class is the controller for the instructions
+// This class is the ViewController for the instructions
 // page.
-class InstructionsViewController: UIViewController, UIWebViewDelegate {
+class InstructionsViewController: UIViewController, WKNavigationDelegate {
 
-    // TODO: UIWebView is deprecated. Replace with WKWebView or
-    // SafariViewController. Note: WKWebView may have problems
+    // Note: WKWebView may have problems
     // when instantiated via storyboards prior to iOS 11.
-    // SafariViewController may (I don't know yet) be difficult
-    // to customize with translucent background rendering to match
-    // the look of the rest of the app.
+    // The storyboard for this scene has a generic UIView
+    // in place to take advantage of the AutoLayout system,
+    // while the main component of the scene, the WKWebView,
+    // is sized to match this UIView and added as a subview.
+    @IBOutlet weak var enclosingView: UIView!
+    var webView: WKWebView! // implicit unwrap seems risky here
     
-    @IBOutlet weak var webView: UIWebView!
     
-    // Load internationalized help text into the webview.
+    // Create and configure the WKWebView and load localized help
+    // text.
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        webView.delegate = self
+        // This could have been done in the storyboard, but
+        // I wanted the view to be visible on the board.
+        enclosingView.backgroundColor = UIColor.clear
+    
+        let webConfiguration = WKWebViewConfiguration()
+        webConfiguration.preferences.javaScriptEnabled = false
+        webView = WKWebView(frame: enclosingView.frame, configuration: webConfiguration)
+    
+        webView.backgroundColor = UIColor.clear
+        webView.isOpaque = false
+        view.addSubview(webView)
+
+        webView.navigationDelegate = self
         
-        // get the preferred language. This should be more flexible,
+        // Get the preferred language. This should be more flexible,
         // but at present the only localizations are English and Spanish.
         var languageCode = "en"
         let preferredLocalization = Bundle.main.preferredLocalizations[0]
         if preferredLocalization.hasPrefix("es")  {
            languageCode = "es"
         }
-        
+      
         if let url = Bundle.main.url(forResource: "information_" + languageCode, withExtension: "html")  {
-            if let htmlData = try? Data(contentsOf: url )  {
-                let baseUrl = URL(fileURLWithPath: Bundle.main.bundlePath)
-                webView.load(htmlData, mimeType: "text/html", textEncodingName: "UTF-8", baseURL: baseUrl)
-            }
+            webView.loadFileURL(url, allowingReadAccessTo: url)
         }
-     
     }
     
-    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        webView.frame = enclosingView.frame
+    }
+
     // Load links in the about page in the Safari app, instead of the
     // WebView. This avoids the following problems and work:
     //    1. App Transport Security issues with http websites
@@ -53,14 +67,14 @@ class InstructionsViewController: UIViewController, UIWebViewDelegate {
     //
     //   There was a problem with VoiceOver when connecting to the GitHub
     //   link in the initial test.
-    func webView(_ webView: UIWebView, shouldStartLoadWith request: URLRequest, navigationType: UIWebViewNavigationType) -> Bool {
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         
-        if navigationType == UIWebViewNavigationType.linkClicked {
-            UIApplication.shared.openURL(request.url!)
-            return false
+        if navigationAction.navigationType == .linkActivated  {
+            UIApplication.shared.openURL(navigationAction.request.url!)
+            decisionHandler(.cancel)
+        } else  {
+            decisionHandler(.allow)
         }
-      
-        return true
     }
-   
+    
 }

--- a/Re-Resolver/about_page/information_en.html
+++ b/Re-Resolver/about_page/information_en.html
@@ -1,5 +1,7 @@
 <html>
-    <head><meta http-equiv="content-type" content="text/html;charset=utf-8">
+    <head>
+        <meta http-equiv="content-type" content="text/html;charset=utf-8">
+        <meta name="viewport" content="initial-scale=1.0">
         <style>
             body  {
                 color: white;
@@ -26,7 +28,8 @@
         </style>
         <title>
             Re-Resolver Information
-        </title></head>
+        </title>
+    </head>
     
     <body>
         

--- a/Re-Resolver/about_page/information_es.html
+++ b/Re-Resolver/about_page/information_es.html
@@ -1,5 +1,7 @@
 <html>
-    <head><meta http-equiv="content-type" content="text/html;charset=utf-8">
+    <head>
+        <meta http-equiv="content-type" content="text/html;charset=utf-8">
+        <meta name="viewport" content="initial-scale=1.0">
         <style>
             body  {
                 color: white;
@@ -26,7 +28,8 @@
         </style>
         <title>
             Re-Resolver Información
-        </title></head>
+        </title>
+    </head>
     
     <body>
         


### PR DESCRIPTION
The UIWebView class used to show the HTML file in the instructions page has been deprecated. These changes replace the UIWebView with WKWebView, and make a slight viewport change to the HTML file so that the WKWebView doesn't shrink the page to fit when it is loaded.