### PR TITLE
Add the "Proud Prism" theme

### DIFF
--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="nsd-RZ-qAF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="nsd-RZ-qAF">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -131,7 +131,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Color Name" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J4u-KG-ubj">
-                                            <rect key="frame" x="8" y="160" width="184" height="21"/>
+                                            <rect key="frame" x="8" y="160.5" width="184" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
@@ -195,9 +195,9 @@
                                     <segue destination="x4Y-t4-eoT" kind="show" identifier="ChoiceResults" id="WTS-Xr-Ql2"/>
                                 </connections>
                             </button>
-                            <tableView clipsSubviews="YES" alpha="0.5" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pbU-eN-Vzo">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="pbU-eN-Vzo">
                                 <rect key="frame" x="20" y="137" width="335" height="433"/>
-                                <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="choiceCell" textLabel="B28-1m-xvI" style="IBUITableViewCellStyleDefault" id="IEq-kZ-n1N">
                                         <rect key="frame" x="0.0" y="28" width="335" height="44"/>
@@ -209,15 +209,15 @@
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Choice" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="B28-1m-xvI">
                                                     <rect key="frame" x="15" y="0.0" width="305" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.5" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </tableViewCellContentView>
-                                        <color key="backgroundColor" red="0.086274509799999996" green="0.090196078430000007" blue="0.10980392160000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <connections>
                                             <segue destination="3ox-f8-JdB" kind="show" identifier="EditChoice" id="IYw-VW-2lN"/>
                                         </connections>
@@ -278,7 +278,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="32"/>
                                 <inset key="titleEdgeInsets" minX="30" minY="0.0" maxX="30" maxY="0.0"/>
                                 <state key="normal" backgroundImage="answer">
-                                    <color key="titleColor" red="0.56470588235294117" green="0.59215686274509804" blue="0.6705882352941176" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="titleColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>
                                     <action selector="choiceButtonPressed:" destination="x4Y-t4-eoT" eventType="touchUpInside" id="fPG-kc-wgy"/>
@@ -459,7 +459,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="CaK-5P-DI7"/>
-        <segue reference="hNu-Qj-7nf"/>
+        <segue reference="WTS-Xr-Ql2"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 </document>

--- a/Re-Resolver/ResolverConstants.swift
+++ b/Re-Resolver/ResolverConstants.swift
@@ -71,6 +71,20 @@ struct ResolverConstants  {
     // TODO: Assign names to color scheme constants before adding to array.
     // Would an enumeration be appropriate?
     
+    
+    // This particular color scheme is defined here because the colorList Array, below was
+    // becoming too complex for the compiler to evaluate quickly. Other color schemes are defined
+    // directly in the colorList array
+    static let prideColors = ColorScheme(colorName: NSLocalizedString("Proud Prism", comment: "Pride Flag Inspired"),
+                                         colorComponents:
+        [CGFloat(231.0 / 255.0), 0.0, 0.0, 1.0,
+         1.0, CGFloat(140.0 / 255.0), 0.0, 1.0,
+         1.0, CGFloat(239.0 / 255.0), 0.0, 1.0,
+         0.0, CGFloat(129.0 / 255.0), CGFloat(31.0 / 255.0), 1.0,
+         0.0, CGFloat(68.0 / 255.0), 1.0, 1.0,
+         CGFloat(118.0 / 255.0), 0.0, CGFloat(137.0 / 255.0), 1.0]
+    )
+    
     // TODO: consider moving color schemes out of this file and into ResolverGradientView
     static let colorList = [
         ColorScheme(colorName: NSLocalizedString("Dark Calm", comment: "dark gray black scheme"),
@@ -108,5 +122,6 @@ struct ResolverConstants  {
             [0.0, 0.0, 0.0, 1,
              0.0, 0.0, 0.0, 1]    // This is a hack, as the theming system was designed for gradients
         ),
+        prideColors
     ]
 }

--- a/Re-Resolver/ResolverGradientView.swift
+++ b/Re-Resolver/ResolverGradientView.swift
@@ -37,10 +37,11 @@ class ResolverGradientView: UIView {
                 colorComponents = ResolverConstants.colorList[0].colorComponents
             }
         }
-        let locations: [CGFloat] = [0, 1]
         
         let colorSpace = CGColorSpaceCreateDeviceRGB()
-        let gradient = CGGradient(colorSpace: colorSpace, colorComponents: colorComponents!, locations: locations, count: 2)
+        // Each color is composed of four component values - red, green, blue, alpha - therefore the color count for the gradient is
+        // the number of components, divided by four
+        let gradient = CGGradient(colorSpace: colorSpace, colorComponents: colorComponents!, locations: nil, count: colorComponents!.count / 4)
         
         
         let context = UIGraphicsGetCurrentContext()

--- a/Re-Resolver/es.lproj/Localizable.strings
+++ b/Re-Resolver/es.lproj/Localizable.strings
@@ -85,3 +85,5 @@
 "Through Kate's Eyes" = "A través de los ojos de Kate"; /* orange-red color scheme */
 
 "Midnight" = "Medianoche";  /* pure black color scheme - no gradient */
+
+"Proud Prism" = "Arco Orgulloso";  /* rainbow color scheme */


### PR DESCRIPTION
This is an update in preparation for pride month.

This theme was inspired by the LGBT pride flag. In addition to the
new rainbow theme, the contrast of text labels on some screens was increased for
better visibility (in particular, with this theme).

I may adjust the theme later - a first impression is that it may be a bit heavy on the warm side of the spectrum, and the cool colors are overwhelmed.
![rainbow-resolver](https://user-images.githubusercontent.com/6785790/40577822-313bd9fe-60d9-11e8-9621-6918d757e89c.jpeg)