### PR TITLE
Support dynamic type sizes

### DIFF
--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -130,9 +130,9 @@
                                     <rect key="frame" x="0.0" y="0.0" width="200" height="340"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Color Name" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J4u-KG-ubj">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Color Name" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J4u-KG-ubj">
                                             <rect key="frame" x="8" y="160" width="184" height="21"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>

--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -348,12 +348,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Oaw-Oo-BK3">
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Oaw-Oo-BK3">
                                 <rect key="frame" x="20" y="164" width="335" height="30"/>
                                 <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" hint="Allows entry of a new choice." label="Choice"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                             </textField>
                         </subviews>

--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -315,10 +315,10 @@
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
-                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Recent Choice" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="S4J-tx-nwW">
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Recent Choice" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="S4J-tx-nwW">
                                             <rect key="frame" x="16" y="0.0" width="343" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>

--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="nsd-RZ-qAF">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="nsd-RZ-qAF">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,12 +13,12 @@
         <!--Menu-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ResolverMenuViewController" customModule="Re_Resolver" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ResolverMenuViewController" customModule="ReResolver" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="ResolverGradientView" customModule="Re_Resolver" customModuleProvider="target">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC" customClass="ResolverGradientView" customModule="ReResolver" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -111,7 +111,7 @@
         <!--Select Color-->
         <scene sceneID="B43-Mh-CfL">
             <objects>
-                <collectionViewController id="ByA-4I-H7s" customClass="ColorCollectionViewController" customModule="Re_Resolver" customModuleProvider="target" sceneMemberID="viewController">
+                <collectionViewController id="ByA-4I-H7s" customClass="ColorCollectionViewController" customModule="ReResolver" customModuleProvider="target" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="i0C-QJ-EnU">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -123,7 +123,7 @@
                             <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         </collectionViewFlowLayout>
                         <cells>
-                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ColorCell" id="fab-3o-dWB" customClass="ColorCollectionViewCell" customModule="Re_Resolver" customModuleProvider="target">
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="ColorCell" id="fab-3o-dWB" customClass="ColorCollectionViewCell" customModule="ReResolver" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="105.5" width="200" height="340"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO">
@@ -170,12 +170,12 @@
         <!--Choose-->
         <scene sceneID="ibD-bT-xv7">
             <objects>
-                <viewController id="8P0-yB-YBp" customClass="ChooseViewController" customModule="Re_Resolver" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="8P0-yB-YBp" customClass="ChooseViewController" customModule="ReResolver" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="MzG-T1-hW7"/>
                         <viewControllerLayoutGuide type="bottom" id="rAl-oT-ir8"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="kMX-sr-pZg" customClass="ResolverGradientView" customModule="Re_Resolver" customModuleProvider="target">
+                    <view key="view" contentMode="scaleToFill" id="kMX-sr-pZg" customClass="ResolverGradientView" customModule="ReResolver" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -259,12 +259,12 @@
         <!--Choice Results View Controller-->
         <scene sceneID="Boo-dC-c6G">
             <objects>
-                <viewController id="x4Y-t4-eoT" customClass="ChoiceResultsViewController" customModule="Re_Resolver" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="x4Y-t4-eoT" customClass="ChoiceResultsViewController" customModule="ReResolver" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="k3K-65-RjU"/>
                         <viewControllerLayoutGuide type="bottom" id="ZCe-ad-3iY"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="iGG-ex-Kiq" customClass="ResolverGradientView" customModule="Re_Resolver" customModuleProvider="target">
+                    <view key="view" contentMode="scaleToFill" id="iGG-ex-Kiq" customClass="ResolverGradientView" customModule="ReResolver" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -302,7 +302,7 @@
         <!--Recent Table View Controller-->
         <scene sceneID="D8e-Ba-NhC">
             <objects>
-                <tableViewController id="m24-Wb-tmy" customClass="RecentTableViewController" customModule="Re_Resolver" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="m24-Wb-tmy" customClass="RecentTableViewController" customModule="ReResolver" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="JGi-0E-WaC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -339,12 +339,12 @@
         <!--New Choice-->
         <scene sceneID="YUk-Ie-dVU">
             <objects>
-                <viewController id="3ox-f8-JdB" customClass="ChoiceDetailViewController" customModule="Re_Resolver" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="3ox-f8-JdB" customClass="ChoiceDetailViewController" customModule="ReResolver" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="2gc-Zh-HKm"/>
                         <viewControllerLayoutGuide type="bottom" id="K2a-Cq-0lB"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="SHF-iJ-MrO" customClass="ResolverGradientView" customModule="Re_Resolver" customModuleProvider="target">
+                    <view key="view" contentMode="scaleToFill" id="SHF-iJ-MrO" customClass="ResolverGradientView" customModule="ReResolver" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -382,12 +382,12 @@
         <!--Information-->
         <scene sceneID="gzb-d5-cwh">
             <objects>
-                <viewController id="cXY-o0-P0T" customClass="InstructionsViewController" customModule="Re_Resolver" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="cXY-o0-P0T" customClass="InstructionsViewController" customModule="ReResolver" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="T9P-Ns-EH1"/>
                         <viewControllerLayoutGuide type="bottom" id="e3z-Lp-RxF"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="sC1-LV-2Q5" customClass="ResolverGradientView" customModule="Re_Resolver" customModuleProvider="target">
+                    <view key="view" contentMode="scaleToFill" id="sC1-LV-2Q5" customClass="ResolverGradientView" customModule="ReResolver" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>

--- a/Re-Resolver/Base.lproj/Main.storyboard
+++ b/Re-Resolver/Base.lproj/Main.storyboard
@@ -206,11 +206,11 @@
                                             <rect key="frame" x="0.0" y="0.0" width="335" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Choice" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="B28-1m-xvI">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Choice" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" id="B28-1m-xvI">
                                                     <rect key="frame" x="15" y="0.0" width="305" height="44"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
@@ -459,7 +459,7 @@
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="CaK-5P-DI7"/>
-        <segue reference="hNu-Qj-7nf"/>
+        <segue reference="WTS-Xr-Ql2"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 </document>

--- a/Re-Resolver/ChooseViewController.swift
+++ b/Re-Resolver/ChooseViewController.swift
@@ -108,6 +108,12 @@ RecentItemDelegate {
         // Configure the cell...
         cell.textLabel?.text = choiceList.choices[(indexPath as NSIndexPath).row]
         cell.textLabel?.textColor = .white
+        
+        // When the text size is changed with Dynamic Type
+        // while this screen is displayed, the text labels
+        // don't quite extend all the way to the end of the
+        // table view. This fixes/hides that issue.
+        cell.textLabel?.backgroundColor = .black
         return cell
     }
     

--- a/Re-Resolver/ChooseViewController.swift
+++ b/Re-Resolver/ChooseViewController.swift
@@ -55,6 +55,10 @@ RecentItemDelegate {
             }
         }
         
+        // allow rows to resize to accomodate multiple lines
+        tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.estimatedRowHeight = 40.0
+        
         // Adjust insets so that text on the custom
         // button appears centered.
         chooseButton.titleEdgeInsets = UIEdgeInsetsMake(0, 0, 20.0, 0)
@@ -103,6 +107,7 @@ RecentItemDelegate {
 
         // Configure the cell...
         cell.textLabel?.text = choiceList.choices[(indexPath as NSIndexPath).row]
+        cell.textLabel?.textColor = .white
         return cell
     }
     

--- a/Re-Resolver/ChooseViewController.swift
+++ b/Re-Resolver/ChooseViewController.swift
@@ -108,12 +108,6 @@ RecentItemDelegate {
         // Configure the cell...
         cell.textLabel?.text = choiceList.choices[(indexPath as NSIndexPath).row]
         cell.textLabel?.textColor = .white
-        
-        // When the text size is changed with Dynamic Type
-        // while this screen is displayed, the text labels
-        // don't quite extend all the way to the end of the
-        // table view. This fixes/hides that issue.
-        cell.textLabel?.backgroundColor = .black
         return cell
     }
     

--- a/Re-Resolver/InstructionsViewController.swift
+++ b/Re-Resolver/InstructionsViewController.swift
@@ -53,6 +53,10 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
         if let url = Bundle.main.url(forResource: "information_" + languageCode, withExtension: "html")  {
             webView.loadFileURL(url, allowingReadAccessTo: url)
         }
+        
+        // listen for dynamic type text size changes
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIContentSizeCategoryDidChange,
+             object: nil, queue: nil, using: {_ in self.webView.reload()})
     }
 
     // Overridden to set the webView to fill
@@ -80,5 +84,10 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
         } else  {
             decisionHandler(.allow)
         }
+    }
+    
+    deinit {
+        // tell the notification center that we won't pay attention to text size changes anymore
+        NotificationCenter.default.removeObserver(self, name: .UIContentSizeCategoryDidChange, object: nil)
     }
 }

--- a/Re-Resolver/RecentTableViewController.swift
+++ b/Re-Resolver/RecentTableViewController.swift
@@ -23,6 +23,13 @@ class RecentTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        // support dynamic type
+        // label is also configured with 0 rows,
+        // body text style, word wrap, and automatically
+        // resize in interface builder
+        tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.estimatedRowHeight = 40.0
+        
         choiceList.dataFileName = ResolverConstants.recentChoicesFileName
         choiceList.load()
         

--- a/Re-Resolver/about_page/information.css
+++ b/Re-Resolver/about_page/information.css
@@ -1,0 +1,23 @@
+body  {
+    color: white;
+}
+
+a  {
+    color: white;
+    font-weight: bold;
+}
+
+table, th, td {
+    border: 1px solid white
+}
+
+th  {
+    padding: 5px;
+    text-align: left;
+}
+
+td  {
+    padding: 5px;
+    font-variant: small-caps;
+}
+

--- a/Re-Resolver/about_page/information.css
+++ b/Re-Resolver/about_page/information.css
@@ -1,5 +1,6 @@
 body  {
     color: white;
+    font: -apple-system-body;
 }
 
 a  {

--- a/Re-Resolver/about_page/information_en.html
+++ b/Re-Resolver/about_page/information_en.html
@@ -2,30 +2,7 @@
     <head>
         <meta http-equiv="content-type" content="text/html;charset=utf-8">
         <meta name="viewport" content="initial-scale=1.0">
-        <style>
-            body  {
-                color: white;
-            }
-        
-        a  {
-            color: white;
-            font-weight: bold;
-        }
-        
-        table, th, td {
-            border: 1px solid white
-        }
-        
-        th  {
-            padding: 5px;
-            text-align: left;
-        }
-        
-        td  {
-            padding: 5px;
-            font-variant: small-caps;
-        }
-        </style>
+        <link rel="stylesheet" href="information.css">
         <title>
             Re-Resolver Information
         </title>

--- a/Re-Resolver/about_page/information_es.html
+++ b/Re-Resolver/about_page/information_es.html
@@ -2,30 +2,7 @@
     <head>
         <meta http-equiv="content-type" content="text/html;charset=utf-8">
         <meta name="viewport" content="initial-scale=1.0">
-        <style>
-            body  {
-                color: white;
-            }
-        
-        a  {
-            color: white;
-            font-weight: bold;
-        }
-        
-        table, th, td {
-            border: 1px solid white
-        }
-        
-        th  {
-            padding: 5px;
-            text-align: left;
-        }
-        
-        td  {
-            padding: 5px;
-            font-variant: small-caps;
-        }
-        </style>
+        <link rel="stylesheet" href="information.css">
         <title>
             Re-Resolver Información
         </title>

--- a/ReResolver.xcodeproj/project.pbxproj
+++ b/ReResolver.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		376A88491CE638A2008C7659 /* ResolverGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376A88481CE638A2008C7659 /* ResolverGradientView.swift */; };
 		377010F51FE87F7300316199 /* ResolverConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C8A09B1CE8B8D400AE3B1F /* ResolverConstants.swift */; };
 		377010F61FE87F8900316199 /* ChoiceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C8A0991CE8B7A100AE3B1F /* ChoiceList.swift */; };
+		377508F61FF03EC800294764 /* information.css in Resources */ = {isa = PBXBuildFile; fileRef = 377508F51FF03EC800294764 /* information.css */; };
 		377869861FCA4CD700EA9DFC /* information_en.html in Resources */ = {isa = PBXBuildFile; fileRef = 377869851FCA4CD700EA9DFC /* information_en.html */; };
 		37C8A09A1CE8B7A100AE3B1F /* ChoiceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C8A0991CE8B7A100AE3B1F /* ChoiceList.swift */; };
 		37C8A09C1CE8B8D400AE3B1F /* ResolverConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C8A09B1CE8B8D400AE3B1F /* ResolverConstants.swift */; };
@@ -60,6 +61,7 @@
 		376A883E1CE62D6A008C7659 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		376A88401CE62D6A008C7659 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		376A88481CE638A2008C7659 /* ResolverGradientView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResolverGradientView.swift; sourceTree = "<group>"; };
+		377508F51FF03EC800294764 /* information.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = information.css; sourceTree = "<group>"; };
 		377869851FCA4CD700EA9DFC /* information_en.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = information_en.html; sourceTree = "<group>"; };
 		37C8A0991CE8B7A100AE3B1F /* ChoiceList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChoiceList.swift; sourceTree = "<group>"; };
 		37C8A09B1CE8B8D400AE3B1F /* ResolverConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResolverConstants.swift; sourceTree = "<group>"; };
@@ -92,6 +94,7 @@
 			children = (
 				3717DD571FCB5EAD001E4359 /* information_es.html */,
 				377869851FCA4CD700EA9DFC /* information_en.html */,
+				377508F51FF03EC800294764 /* information.css */,
 			);
 			path = about_page;
 			sourceTree = "<group>";
@@ -250,6 +253,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				377869861FCA4CD700EA9DFC /* information_en.html in Resources */,
+				377508F61FF03EC800294764 /* information.css in Resources */,
 				3717DD581FCB5EAD001E4359 /* information_es.html in Resources */,
 				376A883F1CE62D6A008C7659 /* LaunchScreen.storyboard in Resources */,
 				37C923A01DEBA94B00D09F64 /* Localizable.strings in Resources */,


### PR DESCRIPTION
This adds iOS Dynamic Type text size support to several screens:

- Information/Instructions
- Select Color
- Choose list
- Add new choice
- Edit existing choice
- Recent Choices

Changing the text size in the iOS Settings app, under Settings->General->Accessibility->Larger Text, will change the size of the text on the above listed screens. On most devices, there is no need to restart the app for the changes to take place - the font size will update immediately.

Some users may notice that the typeface for Information screen has also changed to a font that is purported to be easier to read.

Dynamic Type support has not yet been added to the results screens, with the glassy square pane that displays the answer to a question. The text is already somewhat larger here, and there's some puzzling and decision making still to be done about how to change these screens to accommodate larger text without changing the essential character of the original Resolver app.
