### PR TITLE
WIP: Updates for Swift 4.2 and Xcode 10

### DIFF
--- a/Re-Resolver/AppDelegate.swift
+++ b/Re-Resolver/AppDelegate.swift
@@ -15,7 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var backgroundGradient = ResolverConstants.colorList[0].colorComponents
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         
         // register defaults for background gradient

--- a/Re-Resolver/ChoiceResultsViewController.swift
+++ b/Re-Resolver/ChoiceResultsViewController.swift
@@ -32,7 +32,7 @@ class ChoiceResultsViewController: UIViewController {
     @IBAction func choiceButtonPressed(_ button: UIButton) {
         
         let choice = choiceList.choose()
-        button.setTitle(choice, for: UIControlState())
+        button.setTitle(choice, for: UIControl.State())
         choiceButton.accessibilityLabel = choice
     }
     
@@ -53,7 +53,7 @@ class ChoiceResultsViewController: UIViewController {
             // Check that there are choices before displaying one!
             if choiceList.choices.count > 0  {
                 let choice =  choiceList.choose()
-                choiceButton.setTitle(choice, for: UIControlState())
+                choiceButton.setTitle(choice, for: UIControl.State())
                 choiceButton.accessibilityLabel = choice
             }
         }
@@ -71,7 +71,7 @@ class ChoiceResultsViewController: UIViewController {
     // When a shake is detected, pick an answer again,
     // animate the label change, and then make the phone vibrate when the
     // animation is finished
-    override func motionEnded(_ motion: UIEventSubtype, with event: UIEvent?) {
+    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
         
         if motion == .motionShake  && choiceList.choices.count > 0  {
                 
@@ -79,11 +79,11 @@ class ChoiceResultsViewController: UIViewController {
                 UIView.transition(with: choiceButton.titleLabel!, duration: 0.5, options: .transitionFlipFromLeft,
                                           animations: {
                                             let choice = self.choiceList.choose()
-                                            self.choiceButton.setTitle(choice, for: UIControlState())
+                                            self.choiceButton.setTitle(choice, for: UIControl.State())
                                             self.choiceButton.accessibilityLabel = choice
                                             
                                             // If VoiceOver is enabled, speak the new result
-                                            UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, choice)
+                                            UIAccessibility.post(notification: UIAccessibility.Notification.announcement, argument: choice)
                     }, completion: { animationWasSuccessful in
                         if animationWasSuccessful {
                             AudioServicesPlayAlertSound(kSystemSoundID_Vibrate)

--- a/Re-Resolver/ChooseViewController.swift
+++ b/Re-Resolver/ChooseViewController.swift
@@ -56,12 +56,12 @@ RecentItemDelegate {
         }
         
         // allow rows to resize to accomodate multiple lines
-        tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 40.0
         
         // Adjust insets so that text on the custom
         // button appears centered.
-        chooseButton.titleEdgeInsets = UIEdgeInsetsMake(0, 0, 20.0, 0)
+        chooseButton.titleEdgeInsets = UIEdgeInsets.init(top: 0, left: 0, bottom: 20.0, right: 0)
         
         // Use the original choose button image provided by
         // Fancy Pants Global if the app is using English.
@@ -116,7 +116,7 @@ RecentItemDelegate {
     // Swipe to delete rows
     // This deletes a row from the current choices table,
     // but leaves the row in the recent table
-    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             // Delete the row from the data source
             let choicesIndex = (indexPath as NSIndexPath).row

--- a/Re-Resolver/InstructionsViewController.swift
+++ b/Re-Resolver/InstructionsViewController.swift
@@ -78,10 +78,8 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
     //   link in the initial test that used UIWebView instead of WKWebView.
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         
-        // TODO: KRG 2018-09-14 check use of helper dictionary
-        // conversion function
         if navigationAction.navigationType == .linkActivated  {
-            UIApplication.shared.open(navigationAction.request.url!, options: convertToUIApplicationOpenExternalURLOptionsKeyDictionary([:]), completionHandler: nil)
+            UIApplication.shared.open(navigationAction.request.url!)
             decisionHandler(.cancel)
         } else  {
             decisionHandler(.allow)
@@ -92,11 +90,4 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
         // tell the notification center that we won't pay attention to text size changes anymore
         NotificationCenter.default.removeObserver(self, name: UIContentSizeCategory.didChangeNotification, object: nil)
     }
-}
-
-// TODO: KRG 2018-09-14 check need for this function,
-// and its use above
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertToUIApplicationOpenExternalURLOptionsKeyDictionary(_ input: [String: Any]) -> [UIApplication.OpenExternalURLOptionsKey: Any] {
-	return Dictionary(uniqueKeysWithValues: input.map { key, value in (UIApplication.OpenExternalURLOptionsKey(rawValue: key), value)})
 }

--- a/Re-Resolver/InstructionsViewController.swift
+++ b/Re-Resolver/InstructionsViewController.swift
@@ -55,7 +55,7 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
         }
         
         // listen for dynamic type text size changes
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.UIContentSizeCategoryDidChange,
+        NotificationCenter.default.addObserver(forName: UIContentSizeCategory.didChangeNotification,
              object: nil, queue: nil, using: {_ in self.webView.reload()})
     }
 
@@ -78,8 +78,10 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
     //   link in the initial test that used UIWebView instead of WKWebView.
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         
+        // TODO: KRG 2018-09-14 check use of helper dictionary
+        // conversion function
         if navigationAction.navigationType == .linkActivated  {
-            UIApplication.shared.open(navigationAction.request.url!, options: [:], completionHandler: nil)
+            UIApplication.shared.open(navigationAction.request.url!, options: convertToUIApplicationOpenExternalURLOptionsKeyDictionary([:]), completionHandler: nil)
             decisionHandler(.cancel)
         } else  {
             decisionHandler(.allow)
@@ -88,6 +90,13 @@ class InstructionsViewController: UIViewController, WKNavigationDelegate {
     
     deinit {
         // tell the notification center that we won't pay attention to text size changes anymore
-        NotificationCenter.default.removeObserver(self, name: .UIContentSizeCategoryDidChange, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIContentSizeCategory.didChangeNotification, object: nil)
     }
+}
+
+// TODO: KRG 2018-09-14 check need for this function,
+// and its use above
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertToUIApplicationOpenExternalURLOptionsKeyDictionary(_ input: [String: Any]) -> [UIApplication.OpenExternalURLOptionsKey: Any] {
+	return Dictionary(uniqueKeysWithValues: input.map { key, value in (UIApplication.OpenExternalURLOptionsKey(rawValue: key), value)})
 }

--- a/Re-Resolver/RecentTableViewController.swift
+++ b/Re-Resolver/RecentTableViewController.swift
@@ -27,7 +27,7 @@ class RecentTableViewController: UITableViewController {
         // label is also configured with 0 rows,
         // body text style, word wrap, and automatically
         // resize in interface builder
-        tableView.rowHeight = UITableViewAutomaticDimension
+        tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 40.0
         
         choiceList.dataFileName = ResolverConstants.recentChoicesFileName
@@ -68,7 +68,7 @@ class RecentTableViewController: UITableViewController {
     }
     
     // Enable slide to delete on the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
             
             // Delete the row from the data source

--- a/Re-Resolver/ResolverMenuViewController.swift
+++ b/Re-Resolver/ResolverMenuViewController.swift
@@ -82,9 +82,9 @@ class ResolverMenuViewController: UIViewController {
             // required after i18n and applies only
             // to languages other than English.
             //
-            decideButton.titleEdgeInsets = UIEdgeInsetsMake(0, 0, 20.0, 0)
-            chooseButton.titleEdgeInsets = UIEdgeInsetsMake(0, 0, 20.0, 0)
-            askButton.titleEdgeInsets = UIEdgeInsetsMake(0, 0, 20.0, 0)
+            decideButton.titleEdgeInsets = UIEdgeInsets.init(top: 0, left: 0, bottom: 20.0, right: 0)
+            chooseButton.titleEdgeInsets = UIEdgeInsets.init(top: 0, left: 0, bottom: 20.0, right: 0)
+            askButton.titleEdgeInsets = UIEdgeInsets.init(top: 0, left: 0, bottom: 20.0, right: 0)
         }
        
     }

--- a/ReResolver.xcodeproj/project.pbxproj
+++ b/ReResolver.xcodeproj/project.pbxproj
@@ -211,12 +211,13 @@
 				TargetAttributes = {
 					37399A131FE87A090080CB91 = {
 						CreatedOnToolsVersion = 9.2;
+						LastSwiftMigration = 1000;
 						ProvisioningStyle = Automatic;
 						TestTargetID = 376A88301CE62D69008C7659;
 					};
 					376A88301CE62D69008C7659 = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1000;
 					};
 				};
 			};
@@ -349,7 +350,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.superclassconsulting.ReResolverUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = ReResolver;
 			};
@@ -370,7 +371,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.superclassconsulting.ReResolverUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = 1;
 				TEST_TARGET_NAME = ReResolver;
 			};
@@ -490,8 +491,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.superclassconsulting.ReResolver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -503,8 +503,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.superclassconsulting.ReResolver;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
These are updates to Re-Resolver for Xcode 10 and Swift 4.2.

The app passed the very small set of automated UI tests for Re-Resolver in the simulator, but will need a little more testing on a device, in particular for "shaking the device" on results screens, VoiceOver, and opening external links in the instructions.

The Swift 4.2 automated converter added a helper function in the InstructionsViewController to create an empty options dictionary that's used when an external link is opened with Safari from the instructions page. This seems a bit messy to me so I'll spend a few minutes checking to see if there might be a way to clean it up when I'm better rested.