### PR TITLE
Change "press" in instructions to "tap".

### DIFF
--- a/Re-Resolver/about_page/information_en.html
+++ b/Re-Resolver/about_page/information_en.html
@@ -12,14 +12,14 @@
         
         <h2>Instructions</h2>
         <h3>Decide</h3>
-        <p>Ask a question and then press the widget or shake the phone for a Yes/No answer.</p>
+        <p>Ask a question and then tap the widget or shake the phone for a Yes/No answer.</p>
         
         
         <h3>Choose</h3>
-        <p>Use the + button to add options. Type a new option or use the "Recent" button to add a previous option. Press the "Choose" button and Re-Resolver will pick one of the options.</p>
+        <p>Use the + button to add options. Type a new option or use the "Recent" button to add a previous option. Tap the "Choose" button and Re-Resolver will pick one of the options.</p>
         
         <h3>Ask</h3>
-        <p>Ask a question and then press the widget or shake the phone to get a wordy answer that may be positive, negative, or ambiguous in tone.</p>
+        <p>Ask a question and then tap the widget or shake the phone to get a wordy answer that may be positive, negative, or ambiguous in tone.</p>
         
         <h2>About</h2>
         <p>

--- a/Re-Resolver/about_page/information_es.html
+++ b/Re-Resolver/about_page/information_es.html
@@ -12,14 +12,14 @@
         
         <h2>Instrucciones</h2>
         <h3>Decide</h3>
-        <p>Haz una pregunta y después empujar el widget o agitar el celular por conseguir una respuesta de si/no.</p>
+        <p>Haz una pregunta y después pulsar el widget o agitar el celular por conseguir una respuesta de si/no.</p>
         
         
         <h3>Elige</h3>
-        <p>Usa el botón + para añadir opciones. Escriba una nueva opción o usa el botón  "Recent" para añadir una opción antigua. Presiona el botón "Elige" Y Re-Resolver eligirá una de las opciones.</p>
+        <p>Usa el botón + para añadir opciones. Escriba una nueva opción o usa el botón  "Recent" para añadir una opción antigua. Pulse el botón "Elige" Y Re-Resolver eligirá una de las opciones.</p>
         
         <h3>Pregunta</h3>
-        <p>Haz una pregunta y después empujar el widget o agitar el celular por conseguir una respuesta mas verboso que puede ser positiva, negativa o ambigua.</p>
+        <p>Haz una pregunta y después pulsar el widget o agitar el celular por conseguir una respuesta mas verboso que puede ser positiva, negativa o ambigua.</p>
         
         <h2>Acerca de</h2>
         <p>


### PR DESCRIPTION
This is a mobile app, and normal parlance has users "tapping" the screen instead of "pressing" on it.
The "press" verb could be confused with 3D Touch present on some phone models.