### PR TITLE
Remove call to UserDefaults.synchronize()

### DIFF
--- a/Re-Resolver/ColorCollectionViewController.swift
+++ b/Re-Resolver/ColorCollectionViewController.swift
@@ -105,7 +105,6 @@ class ColorCollectionViewController: UICollectionViewController {
           
             // store color scheme as user preference
             UserDefaults.standard.set((indexPath as NSIndexPath).row, forKey: "ColorPreference")
-            UserDefaults.standard.synchronize()
         }
     }
     
@@ -116,13 +115,12 @@ class ColorCollectionViewController: UICollectionViewController {
         // This is a workaround for when a selected cell is scrolled just
         // slightly off screen and remains in memory while another cell is selected.
         //
-        // When the originally cell appears on screen again, it looks to be in the selected state
+        // When the original cell appears on screen again, it looks to be in the selected state
         // with the thick border even though it has been deselected.
         //
         // This hack forces the cell to reload so the appearance will be different
         // when it appears on-screen again.
         // I suspect I am handling selection state/ selected appearance incorrectly.
-        //collectionView.reloadData()
         collectionView.reloadItems(at: [indexPath])
     }
     


### PR DESCRIPTION
At some point I'd read that it was important to call synchronize()
after setting a UserDefault preference (in this case, color) in order
to make sure that the value was flushed to the disk.

This method is now described in Apple documentation for the iOS 12 SDK with
"this method is unnecessary and should not be used".  Some information from
David Smith, the developer who worked on deprecating the call, indicates that
it may even hurt performance in cases where the data to be written is large, and
also that the call doesn't actually flush the data to disk immediately.

A tweet from David indicated that in some rare circumstances under iOS 11 and
earlier, this call may still be needed. I looked for more details, because Re-Resolver
is still supported under iOS 10 and iOS 11, and it seems that these rare instances
are:
   - when the developer (not the user) explicitly exits the app
   - when the user defaults are being used for interprocess communication

Re-Resolver is doing neither of these things, and using this call has been considered
a bad practice for a few years now. I've removed the call and the app tested well
with previous versions of iOS in the simulator.

This ViewController also updates the preferences every time the user taps a
new color scheme, instead of doing only one update when the user taps on "Done"
to close the view. I wonder if that might be a bad practice as well, but I don't address
that potential problem with this change.