### PR TITLE
Update links to privacy policy

### DIFF
--- a/Re-Resolver/about_page/information_en.html
+++ b/Re-Resolver/about_page/information_en.html
@@ -59,7 +59,7 @@
         
         <h2>Privacy Policy</h2>
         <p>
-          The current <a href="https://github.com/keithgee/Re-Resolver/blob/master/Privacy-Policy.md">privacy policy</a> is available on GitHub.
+          The current <a href="https://github.com/keithgee/Re-Resolver/blob/main/Privacy-Policy.md">privacy policy</a> is available on GitHub.
         </p>
         
         <h2>Thanks</h2>

--- a/Re-Resolver/about_page/information_es.html
+++ b/Re-Resolver/about_page/information_es.html
@@ -59,7 +59,7 @@
         
         <h2>Política de Privacidad</h2>
         <p>
-        La <a href="https://github.com/keithgee/Re-Resolver/blob/master/Privacy-Policy.md">política de privacidad</a> está disponible en GitHub.
+        La <a href="https://github.com/keithgee/Re-Resolver/blob/main/Privacy-Policy.md">política de privacidad</a> está disponible en GitHub.
         </p>
         
         <h2>Thanks</h2>


### PR DESCRIPTION
The master branch has been renamed to main, so the
links to the privacy policy in the information pages
have been udpated.

It's not necessary to deploy this change inmediately.
The current links to the previous master name will be
redirected by GitHub.